### PR TITLE
Echo dagger fix + offhand bonus range applies to main hand

### DIFF
--- a/db/re/item_db_equip.yml
+++ b/db/re/item_db_equip.yml
@@ -4211,7 +4211,7 @@ Body:
     Weight: 600
     Attack: 5
     MagicAttack: 5
-    Range: 4
+    Range: 1
     Jobs:
       All: true
       Acolyte: false
@@ -4236,6 +4236,7 @@ Body:
       DropEffect: RED_PILLAR
     Script: |
       skill "TF_DOUBLE",1;
+      bonus bAtkRange,4;
   - Id: 1216
     AegisName: Stiletto
     Name: Stiletto

--- a/src/map/pc.cpp
+++ b/src/map/pc.cpp
@@ -3358,9 +3358,9 @@ void pc_bonus(struct map_session_data *sd,int type,int val)
 						status->rhw.range += val;
 				}
 				break;
-			case 1:
+			case 1: //Corax: apply range bonus from left hand weapon effects/cards to main hand aswell
 				status->lhw.range += val;
-				break;
+			//	break; //Fallthrough
 			default:
 				status->rhw.range += val;
 				break;


### PR DESCRIPTION
<!-- NOTE: Anything within these brackets will be hidden on the preview of the Pull Request. -->

* **Addressed Issue(s)**: 

\- Echo Dagger states "Attack Range +4" but instead just has a base range of 4 (+3) -> Changed to base range 1 (dagger base) with effect of "attack range +4"
\- Attack Range bonuses from left hand weapons do only apply to the left (off-)hand -> Changed to also apply to the right (main-)hand.

<!--
Please specify the rAthena [GitHub issue(s)](https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests) this pull request amends.
If no issue exists yet, please [create one](https://github.com/rathena/rathena/issues/new) first and then link your pull request to the amendment!
-->

* **Server Mode**: 

<!-- Which mode does this pull request apply to: Pre-Renewal, Renewal, or Both? -->

* **Description of Pull Request**: 

<!-- Describe how this pull request will resolve the issue(s) listed above. -->
